### PR TITLE
fix: :bug: use environment variables for log file paths in view_logs …

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ facebook.com,twitter.com,youtube.com,netflix.com,tiktok.com
    FLASK_DEBUG=True
    DATABASE_TYPE="SQLITE"
    SQUID_LOG="/var/log/squid/access.log"
+   SQUID_CACHE_LOG="/var/log/squid/cache.log"
    DATABASE_STRING_CONNECTION="/opt/SquidStats/"
    REFRESH_INTERVAL=60
    BLACKLIST_DOMAINS="facebook.com,twitter.com,instagram.com,tiktok.com,youtube.com,netflix.com"

--- a/README_es.md
+++ b/README_es.md
@@ -272,6 +272,7 @@ facebook.com,twitter.com,youtube.com,netflix.com,tiktok.com
    FLASK_DEBUG=True
    DATABASE_TYPE="SQLITE"
    SQUID_LOG="/var/log/squid/access.log"
+   SQUID_CACHE_LOG="/var/log/squid/cache.log"
    DATABASE_STRING_CONNECTION="/opt/SquidStats/"
    REFRESH_INTERVAL=60
    BLACKLIST_DOMAINS="facebook.com,twitter.com,instagram.com,tiktok.com,youtube.com,netflix.com"

--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -181,7 +181,10 @@ def manage_http_access():
 
 @admin_bp.route("/view-logs")
 def view_logs():
-    log_files = ["/var/log/squid/access.log", "/var/log/squid/cache.log"]
+    log_files = [
+        os.getenv("SQUID_LOG", "/var/log/squid/access.log"),
+        os.getenv("SQUID_CACHE_LOG", "/var/log/squid/cache.log")
+    ]
     logs = {}
     for log_file in log_files:
         try:


### PR DESCRIPTION

## 🔧 Environment Variables for Log File Paths

### **What Changed**
- Replaced hardcoded log file paths with environment variables for better flexibility and deployment portability.
- Added new environment variable `SQUID_CACHE_LOG`.

### **Before vs After**

**Before (Hardcoded paths):**
```python
@admin_bp.route("/view-logs")
def view_logs():
    log_files = ["/var/log/squid/access.log", "/var/log/squid/cache.log"]
    # ... rest of function
````

**After (Environment variables):**

```python
@admin_bp.route("/view-logs")
def view_logs():
    log_files = [
        os.getenv("SQUID_LOG", "/var/log/squid/access.log"),
        os.getenv("SQUID_CACHE_LOG", "/var/log/squid/cache.log")
    ]
    # ... rest of function
```

### ✅ Files Modified

* **admin_routes.py** → Updated `view_logs()` function to use environment variables.
* **README.md** → Added `SQUID_CACHE_LOG` to environment variables documentation.
* **README_es.md** → Added `SQUID_CACHE_LOG` to Spanish documentation.

### 🌍 New Environment Variable

* `SQUID_CACHE_LOG` → Path to Squid cache log file (default: `/var/log/squid/cache.log`)

