### PR TITLE
Add ssl bump admin

### DIFF
--- a/routes/admin/dashboard.py
+++ b/routes/admin/dashboard.py
@@ -3,6 +3,7 @@
 from flask import render_template
 
 from services.auth.auth_service import admin_required
+from services.squid.ssl_bump_service import get_ssl_bump_status
 
 from .helpers import get_config_manager
 
@@ -21,4 +22,10 @@ def register_routes(bp):
             "total_http_rules": len(http_access_rules),
         }
         status = cm.get_status()
-        return render_template("admin/dashboardAdmin.html", stats=stats, status=status)
+        ssl_bump = get_ssl_bump_status(cm)
+        return render_template(
+            "admin/dashboardAdmin.html",
+            stats=stats,
+            status=status,
+            ssl_bump=ssl_bump,
+        )

--- a/routes/admin/system_api.py
+++ b/routes/admin/system_api.py
@@ -18,8 +18,9 @@ from services.system.system_service import (
 from services.system.system_service import (
     restart_squid as service_restart_squid,
 )
+from services.squid.ssl_bump_service import get_ssl_bump_status
 
-from .helpers import json_error, json_success
+from .helpers import json_error, json_success, get_config_manager
 
 
 def register_routes(bp):
@@ -42,6 +43,18 @@ def register_routes(bp):
         if success:
             return json_success(message)
         return json_error(message, 500, details=details)
+
+    # ------------------------------------------------------------------
+    # SSL Bump detection
+    # ------------------------------------------------------------------
+
+    @bp.route("/api/ssl-bump-status", methods=["GET"])
+    @api_auth_required
+    def ssl_bump_status():
+        cm = get_config_manager()
+        data = get_ssl_bump_status(cm)
+        print("SSL Bump status:", data)  # Debug log
+        return jsonify(data), 200
 
     # ------------------------------------------------------------------
     # Database management

--- a/routes/admin/system_api.py
+++ b/routes/admin/system_api.py
@@ -12,15 +12,15 @@ from services.database.db_admin_service import (
 from services.database.db_info_service import (
     get_tables_info as service_get_tables_info,
 )
+from services.squid.ssl_bump_service import get_ssl_bump_status
 from services.system.system_service import (
     reload_squid as service_reload_squid,
 )
 from services.system.system_service import (
     restart_squid as service_restart_squid,
 )
-from services.squid.ssl_bump_service import get_ssl_bump_status
 
-from .helpers import json_error, json_success, get_config_manager
+from .helpers import get_config_manager, json_error, json_success
 
 
 def register_routes(bp):

--- a/services/squid/squid_config_splitter.py
+++ b/services/squid/squid_config_splitter.py
@@ -106,7 +106,7 @@ class SquidConfigSplitter:
                 [
                     re.compile(r"^ssl_"),
                     re.compile(r"^sslcrtd_"),
-                    re.compile(r"SslBump"),
+                    re.compile(r"^acl\s+\S+\s+at_step\b"),
                     re.compile(r"sslproxy_"),
                 ],
             ),
@@ -137,7 +137,7 @@ class SquidConfigSplitter:
             Rule(
                 "100_acls.conf",
                 [
-                    re.compile(r"^acl(?! auth\b)"),
+                    re.compile(r"^acl(?! auth\b)(?!.*\bat_step\b)"),
                     re.compile(r"^external_acl_type\b"),
                 ],
             ),

--- a/services/squid/ssl_bump_service.py
+++ b/services/squid/ssl_bump_service.py
@@ -1,0 +1,27 @@
+"""Service layer for SSL Bump detection."""
+
+from loguru import logger
+
+
+def get_ssl_bump_status(config_manager) -> dict:
+    """Return SSL Bump detection results from *config_manager*.
+
+    Wraps :meth:`SquidConfigManager.detect_ssl_bump` with error handling so
+    callers always receive a well-formed dict.
+    """
+    try:
+        return config_manager.detect_ssl_bump()
+    except Exception:
+        logger.exception("Error detecting SSL Bump status")
+        return {
+            "enabled": False,
+            "mode": None,
+            "cert": None,
+            "generate_certs": False,
+            "sslcrtd_configured": False,
+            "sslcrtd_children": None,
+            "http_port_entry": None,
+            "ssl_bump_rules": [],
+            "source": "main",
+            "error": "Error al detectar la configuración SSL Bump",
+        }

--- a/static/js/confirm_modal.js
+++ b/static/js/confirm_modal.js
@@ -2,7 +2,12 @@
 let confirmCallback = null;
 
 function showCustomConfirm(message, callback, options = {}) {
-    document.getElementById('confirmMessage').textContent = message;
+    const msgEl = document.getElementById('confirmMessage');
+    if (options.isHtml) {
+        msgEl.innerHTML = message;
+    } else {
+        msgEl.textContent = message;
+    }
     confirmCallback = callback;
     // Polimorfismo visual: solo botón cerrar
     const cancelBtn = document.getElementById('confirmCancelBtn');

--- a/static/js/confirm_modal.js
+++ b/static/js/confirm_modal.js
@@ -1,16 +1,9 @@
 // Confirm Modal Component Logic
 let confirmCallback = null;
 
-function showCustomConfirm(message, callback, options = {}) {
-    const msgEl = document.getElementById('confirmMessage');
-    msgEl.replaceChildren();
-    if (message instanceof Node) {
-        msgEl.appendChild(message);
-    } else {
-        msgEl.textContent = message;
-    }
+// Low-level: open the modal assuming confirmMessage is already populated.
+function openConfirmModal(callback, options = {}) {
     confirmCallback = callback;
-    // Polimorfismo visual: solo botón cerrar
     const cancelBtn = document.getElementById('confirmCancelBtn');
     const confirmBtn = document.getElementById('confirmConfirmBtn');
     if (options.onlyClose) {
@@ -25,6 +18,12 @@ function showCustomConfirm(message, callback, options = {}) {
         confirmBtn.classList.add('bg-red-500', 'hover:bg-red-600');
     }
     document.getElementById('confirmModal').classList.remove('hidden');
+}
+
+// High-level: set a plain-text message and open the modal.
+function showCustomConfirm(message, callback, options = {}) {
+    document.getElementById('confirmMessage').textContent = message;
+    openConfirmModal(callback, options);
 }
 
 function hideConfirmModal() {

--- a/static/js/confirm_modal.js
+++ b/static/js/confirm_modal.js
@@ -3,8 +3,9 @@ let confirmCallback = null;
 
 function showCustomConfirm(message, callback, options = {}) {
     const msgEl = document.getElementById('confirmMessage');
-    if (options.isHtml) {
-        msgEl.innerHTML = message;
+    msgEl.replaceChildren();
+    if (message instanceof Node) {
+        msgEl.appendChild(message);
     } else {
         msgEl.textContent = message;
     }

--- a/templates/admin/dashboardAdmin.html
+++ b/templates/admin/dashboardAdmin.html
@@ -6,7 +6,7 @@
         <h2 class="text-xl sm:text-2xl font-bold text-gray-800 mb-4 sm:mb-6">Dashboard - Resumen del Sistema</h2>
         
         <!-- Stats Cards -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 mb-6 sm:mb-8">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
 
             <!-- ACLs Card -->
             <div class="bg-gradient-to-r from-blue-500 to-blue-600 text-white p-6 rounded-lg">
@@ -83,6 +83,28 @@
                         {% endif %}
                     </div>
                     <i class="fas fa-key text-4xl text-purple-200"></i>
+                </div>
+            </div>
+
+            <!-- SSL Bump Card -->
+            {% if ssl_bump.enabled %}
+            <div class="bg-gradient-to-r from-yellow-500 to-orange-500 text-white p-6 rounded-lg">
+            {% else %}
+            <div class="bg-gradient-to-r from-gray-400 to-gray-500 text-white p-6 rounded-lg">
+            {% endif %}
+                <div class="flex items-center justify-between">
+                    <div>
+                        <p class="{% if ssl_bump.enabled %}text-yellow-100{% else %}text-gray-200{% endif %}">SSL Bump</p>
+                        {% if ssl_bump.enabled %}
+                            <p class="text-2xl font-bold">Activo</p>
+                            {% if ssl_bump.mode %}
+                                <p class="text-xs mt-1 {% if ssl_bump.enabled %}text-yellow-200{% else %}text-gray-300{% endif %}">{{ ssl_bump.mode }}</p>
+                            {% endif %}
+                        {% else %}
+                            <p class="text-2xl font-bold">Inactivo</p>
+                        {% endif %}
+                    </div>
+                    <i class="fas fa-user-secret text-4xl {% if ssl_bump.enabled %}text-yellow-200{% else %}text-gray-300{% endif %}"></i>
                 </div>
             </div>
 
@@ -179,6 +201,26 @@
                     {% else %}
                         <span class="text-blue-600 font-semibold">Cargada</span>
                     {% endif %}
+                </div>
+
+                <div class="flex items-center justify-between p-3 {% if ssl_bump.enabled %}bg-yellow-50{% else %}bg-gray-50{% endif %} rounded-lg">
+                    <div class="flex items-center">
+                        <i class="fas fa-user-secret {% if ssl_bump.enabled %}text-yellow-500{% else %}text-gray-400{% endif %} mr-3"></i>
+                        <span class="font-medium">SSL Bump (MITM)</span>
+                    </div>
+                    <div class="text-right">
+                        {% if ssl_bump.enabled %}
+                            <span class="text-yellow-600 font-semibold">Activo</span>
+                            {% if ssl_bump.mode %}
+                                <span class="ml-2 text-xs bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded-full">{{ ssl_bump.mode }}</span>
+                            {% endif %}
+                            {% if ssl_bump.cert %}
+                                <br><span class="text-xs text-gray-500">cert: {{ ssl_bump.cert }}</span>
+                            {% endif %}
+                        {% else %}
+                            <span class="text-gray-500 font-semibold">Inactivo</span>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/admin/split_config.html
+++ b/templates/admin/split_config.html
@@ -230,23 +230,46 @@
 
     function confirmSplit() {
         const backupFilename = `squid.conf.bak${getCurrentDate()}`;
-        const message = `
-            <div class="space-y-3">
-                <div class="text-base text-gray-900 font-semibold mb-1">¿Está seguro de que desea dividir la configuración de Squid?</div>
-                <div class="bg-blue-50 border border-blue-200 rounded-lg p-3 mt-2 text-left">
-                    <p class="text-sm text-blue-900 mb-2">
-                        <i class="fas fa-info-circle mr-2"></i>
-                        <strong>Esta operación es reversible</strong>
-                    </p>
-                    <p class="text-xs text-blue-800">
-                        Se creará automáticamente una copia de seguridad de tu archivo
-                        <code class="bg-blue-100 px-1 py-0.5 rounded">squid.conf</code> con el nombre:
-                    </p>
-                    <p class="text-xs text-blue-900 font-mono mt-1 bg-blue-100 px-2 py-1 rounded">${backupFilename}</p>
-                </div>
-            </div>
-        `;
-        showCustomConfirm(message, executeSplit, { isHtml: true });
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'space-y-3';
+
+        const title = document.createElement('div');
+        title.className = 'text-base text-gray-900 font-semibold mb-1';
+        title.textContent = '¿Está seguro de que desea dividir la configuración de Squid?';
+        wrapper.appendChild(title);
+
+        const infoBox = document.createElement('div');
+        infoBox.className = 'bg-blue-50 border border-blue-200 rounded-lg p-3 mt-2 text-left';
+
+        const p1 = document.createElement('p');
+        p1.className = 'text-sm text-blue-900 mb-2';
+        const icon = document.createElement('i');
+        icon.className = 'fas fa-info-circle mr-2';
+        const strong = document.createElement('strong');
+        strong.textContent = 'Esta operación es reversible';
+        p1.appendChild(icon);
+        p1.appendChild(strong);
+
+        const p2 = document.createElement('p');
+        p2.className = 'text-xs text-blue-800';
+        p2.append('Se creará automáticamente una copia de seguridad de tu archivo ');
+        const code = document.createElement('code');
+        code.className = 'bg-blue-100 px-1 py-0.5 rounded';
+        code.textContent = 'squid.conf';
+        p2.appendChild(code);
+        p2.append(' con el nombre:');
+
+        const p3 = document.createElement('p');
+        p3.className = 'text-xs text-blue-900 font-mono mt-1 bg-blue-100 px-2 py-1 rounded';
+        p3.textContent = backupFilename;
+
+        infoBox.appendChild(p1);
+        infoBox.appendChild(p2);
+        infoBox.appendChild(p3);
+        wrapper.appendChild(infoBox);
+
+        showCustomConfirm(wrapper, executeSplit);
     }
 
     async function executeSplit() {

--- a/templates/admin/split_config.html
+++ b/templates/admin/split_config.html
@@ -231,6 +231,9 @@
     function confirmSplit() {
         const backupFilename = `squid.conf.bak${getCurrentDate()}`;
 
+        const msgEl = document.getElementById('confirmMessage');
+        msgEl.replaceChildren();
+
         const wrapper = document.createElement('div');
         wrapper.className = 'space-y-3';
 
@@ -268,8 +271,9 @@
         infoBox.appendChild(p2);
         infoBox.appendChild(p3);
         wrapper.appendChild(infoBox);
+        msgEl.appendChild(wrapper);
 
-        showCustomConfirm(wrapper, executeSplit);
+        openConfirmModal(executeSplit);
     }
 
     async function executeSplit() {

--- a/templates/admin/split_config.html
+++ b/templates/admin/split_config.html
@@ -246,7 +246,7 @@
                 </div>
             </div>
         `;
-        showCustomConfirm(message, executeSplit);
+        showCustomConfirm(message, executeSplit, { isHtml: true });
     }
 
     async function executeSplit() {

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -11,9 +11,8 @@ from config import Config
 load_dotenv()
 
 SQUID_CONFIG_PATH = Config.SQUID_CONFIG_PATH or "/etc/squid/squid.conf"
-ACL_FILES_DIR = (
-    os.getenv("ACL_FILES_DIR") or
-    os.path.join(os.path.dirname(SQUID_CONFIG_PATH), "squid.d", "")
+ACL_FILES_DIR = os.getenv("ACL_FILES_DIR") or os.path.join(
+    os.path.dirname(SQUID_CONFIG_PATH), "squid.d", ""
 )
 
 
@@ -1026,12 +1025,8 @@ class SquidConfigManager:
 
         # --- determine mode ---
         if result["enabled"]:
-            has_bump = any(
-                re.match(r"^ssl_bump\s+bump\b", r) for r in ssl_bump_rules
-            )
-            has_peek = any(
-                re.match(r"^ssl_bump\s+peek\b", r) for r in ssl_bump_rules
-            )
+            has_bump = any(re.match(r"^ssl_bump\s+bump\b", r) for r in ssl_bump_rules)
+            has_peek = any(re.match(r"^ssl_bump\s+peek\b", r) for r in ssl_bump_rules)
             has_splice = any(
                 re.match(r"^ssl_bump\s+splice\b", r) for r in ssl_bump_rules
             )

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -1,19 +1,47 @@
 import os
+import re
 import shutil
 from datetime import datetime
 
 from dotenv import load_dotenv
 from loguru import logger
 
+from config import Config
+
 load_dotenv()
 
-# SQUID_CONFIG_PATH = os.getenv("SQUID_CONFIG_PATH", "/etc/squid/squid.conf")
-# ACL_FILES_DIR = os.getenv("ACL_FILES_DIR", "/etc/squid/acls")
-SQUID_CONFIG_PATH = "/etc/squid/squid.conf"
-ACL_FILES_DIR = "/etc/squid/squid.d/"
+SQUID_CONFIG_PATH = Config.SQUID_CONFIG_PATH or "/etc/squid/squid.conf"
+ACL_FILES_DIR = (
+    os.getenv("ACL_FILES_DIR") or
+    os.path.join(os.path.dirname(SQUID_CONFIG_PATH), "squid.d", "")
+)
+
+
+def _join_continuation_lines(content: str) -> str:
+    """Join lines ending with a backslash with the following line."""
+    lines = content.splitlines()
+    result = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        while line.rstrip().endswith("\\"):
+            line = line.rstrip()[:-1]
+            i += 1
+            if i < len(lines):
+                line += " " + lines[i].strip()
+        result.append(line)
+        i += 1
+    return "\n".join(result)
 
 
 def validate_paths():
+    """Validate the squid.conf path (hard errors) and the ACL directory (warnings only).
+
+    Returns a list of *hard* error strings that block SquidConfigManager
+    initialization.  Missing or inaccessible ACL directories are logged as
+    warnings but do NOT appear in the returned list — they only disable
+    modular-config support.
+    """
     errors = []
 
     cfg = os.path.abspath(os.path.expanduser(SQUID_CONFIG_PATH))
@@ -47,13 +75,17 @@ def validate_paths():
                 if not os.access(squid_conf, os.W_OK):
                     errors.append(f"No write permissions for: {squid_conf}")
 
+    # ACL / modular-config directory — warnings only, never a hard error
     acl_dir = os.path.abspath(os.path.expanduser(ACL_FILES_DIR))
     if not os.path.exists(acl_dir):
-        errors.append(f"ACL directory not found: {acl_dir}")
+        logger.warning(
+            f"ACL/modular config directory not found: {acl_dir} — "
+            "modular configuration will be disabled."
+        )
     elif not os.path.isdir(acl_dir):
-        errors.append(f"ACL path is not a directory: {acl_dir}")
+        logger.warning(f"ACL path is not a directory: {acl_dir}")
     elif not os.access(acl_dir, os.W_OK):
-        errors.append(f"No write permissions in ACL directory: {acl_dir}")
+        logger.warning(f"No write permissions in ACL directory: {acl_dir}")
 
     return errors
 
@@ -893,6 +925,127 @@ class SquidConfigManager:
             "config_files_count": len(self.list_modular_configs()),
             "main_config_path": self.config_path,
         }
+
+    def detect_ssl_bump(self) -> dict:
+        """Detect whether SSL Bump is enabled in the Squid configuration.
+
+        Inspects ``http_port`` directives (with backslash-continuation support),
+        ``ssl_bump`` action rules, and ``sslcrtd_*`` directives.
+
+        Returns a dict::
+
+            {
+                "enabled": bool,
+                "mode": "peek-and-splice" | "bump-all" | "custom" | "basic" | None,
+                "cert": str | None,          # path in cert= option
+                "generate_certs": bool,
+                "sslcrtd_configured": bool,
+                "sslcrtd_children": int | None,
+                "http_port_entry": str | None,
+                "ssl_bump_rules": list[str],
+                "source": "main" | "modular",
+            }
+        """
+        result: dict = {
+            "enabled": False,
+            "mode": None,
+            "cert": None,
+            "generate_certs": False,
+            "sslcrtd_configured": False,
+            "sslcrtd_children": None,
+            "http_port_entry": None,
+            "ssl_bump_rules": [],
+            "source": "main",
+        }
+
+        if not self.is_valid:
+            return result
+
+        ports_content = self.config_content
+        ssl_content = self.config_content
+
+        if self.is_modular:
+            # Use os.path.exists to avoid ERROR logs for optional modular files
+            ports_path = os.path.join(self.config_dir, "00_ports.conf")
+            ssl_path = os.path.join(self.config_dir, "55_ssl_bump.conf")
+            if os.path.exists(ports_path):
+                mc_ports = self.read_modular_config("00_ports.conf")
+                if mc_ports:
+                    ports_content = mc_ports
+                    result["source"] = "modular"
+            if os.path.exists(ssl_path):
+                mc_ssl = self.read_modular_config("55_ssl_bump.conf")
+                if mc_ssl:
+                    ssl_content = mc_ssl
+                    result["source"] = "modular"
+
+        # --- http_port: join continuation lines then scan ---
+        joined_ports = _join_continuation_lines(ports_content)
+        for line in joined_ports.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if re.match(r"^http_port\b", stripped):
+                tokens = stripped.split()
+                if "ssl-bump" in tokens:
+                    result["enabled"] = True
+                    result["http_port_entry"] = stripped
+
+                    cert_m = re.search(r"\bcert=(\S+)", stripped)
+                    if cert_m:
+                        result["cert"] = cert_m.group(1)
+
+                    gen_m = re.search(
+                        r"\bgenerate-host-certificates=(on|off)\b", stripped
+                    )
+                    if gen_m:
+                        result["generate_certs"] = gen_m.group(1) == "on"
+                    break
+
+        # --- ssl_bump action rules ---
+        ssl_bump_rules = []
+        for line in ssl_content.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if re.match(r"^ssl_bump\b", stripped):
+                ssl_bump_rules.append(stripped)
+        result["ssl_bump_rules"] = ssl_bump_rules
+
+        # --- sslcrtd_* directives ---
+        for line in ssl_content.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if re.match(r"^sslcrtd_program\b", stripped):
+                result["sslcrtd_configured"] = True
+            elif re.match(r"^sslcrtd_children\b", stripped):
+                m = re.match(r"^sslcrtd_children\s+(\d+)", stripped)
+                if m:
+                    result["sslcrtd_children"] = int(m.group(1))
+
+        # --- determine mode ---
+        if result["enabled"]:
+            has_bump = any(
+                re.match(r"^ssl_bump\s+bump\b", r) for r in ssl_bump_rules
+            )
+            has_peek = any(
+                re.match(r"^ssl_bump\s+peek\b", r) for r in ssl_bump_rules
+            )
+            has_splice = any(
+                re.match(r"^ssl_bump\s+splice\b", r) for r in ssl_bump_rules
+            )
+
+            if has_peek or has_splice:
+                result["mode"] = "peek-and-splice"
+            elif has_bump:
+                result["mode"] = "bump-all"
+            elif ssl_bump_rules:
+                result["mode"] = "custom"
+            else:
+                result["mode"] = "basic"
+
+        return result
 
     def get_status(self):
         return {


### PR DESCRIPTION
This pull request introduces SSL Bump (MITM) detection and reporting throughout the admin dashboard and API, along with improvements to configuration parsing and UI enhancements. The main focus is to provide clear visibility into whether SSL Bump is enabled in the Squid proxy configuration, its mode, and related details. Additional minor improvements include more robust configuration parsing and enhanced confirmation modals.

**SSL Bump Detection and Reporting**

* Added a new `detect_ssl_bump` method to `SquidConfigManager` in `utils/admin.py` to analyze Squid configuration files (including modular configs) and determine if SSL Bump is enabled, its mode, certificate path, and related settings. This method handles line continuations and various directive formats.
* Introduced a service layer (`services/squid/ssl_bump_service.py`) with `get_ssl_bump_status` for safe error-handled access to SSL Bump status, used by both the dashboard and API.
* Updated the admin dashboard (`routes/admin/dashboard.py` and `templates/admin/dashboardAdmin.html`) to display SSL Bump status, mode, and certificate information in both the stats cards and system status sections. [[1]](diffhunk://#diff-f8d7af7bbeec5f091a765e1b98ec67c1050ecd1c482a83b64af42f3703fc97c0R6) [[2]](diffhunk://#diff-f8d7af7bbeec5f091a765e1b98ec67c1050ecd1c482a83b64af42f3703fc97c0L24-R31) [[3]](diffhunk://#diff-22cc4af565568186584b862a1aad9ebf963c27b87b7986aa799c6daa39e2f6ccL9-R9) [[4]](diffhunk://#diff-22cc4af565568186584b862a1aad9ebf963c27b87b7986aa799c6daa39e2f6ccR89-R110) [[5]](diffhunk://#diff-22cc4af565568186584b862a1aad9ebf963c27b87b7986aa799c6daa39e2f6ccR205-R224)
* Added a new API endpoint `/api/ssl-bump-status` to expose SSL Bump detection results for use in the frontend or external integrations. [[1]](diffhunk://#diff-94248b756b5aa52d0f3af93f4ac9c33a19ec2208d677d8e03be85f89929aa691R15-R23) [[2]](diffhunk://#diff-94248b756b5aa52d0f3af93f4ac9c33a19ec2208d677d8e03be85f89929aa691R47-R58)

**Configuration Parsing Improvements**

* Added `_join_continuation_lines` utility to handle backslash-continued lines in Squid configs for robust directive detection.
* Improved ACL directory validation to log warnings instead of blocking startup, making modular config support more resilient.

**Squid Config Splitter Adjustments**

* Refined regex rules in `services/squid/squid_config_splitter.py` to more accurately separate SSL Bump and ACL-related directives, improving modular config splitting. [[1]](diffhunk://#diff-28e7ccd463058756e1ffef526bd392e9d27962ec1c37613c562ed205c88d597aL109-R109) [[2]](diffhunk://#diff-28e7ccd463058756e1ffef526bd392e9d27962ec1c37613c562ed205c88d597aL140-R140)

**Frontend Enhancements**

* Updated the confirmation modal to support HTML content, enabling richer confirmation dialogs (used in split config confirmation). [[1]](diffhunk://#diff-2c0ca4b66848657a6f61d3083d97210b27128c8df4dea0fc1f962364f0c60eceL5-R10) [[2]](diffhunk://#diff-9d9abf21d8d6a828b57e2ebf9f18ae4cf7653a76105c1ad129daea5f95a4e09bL249-R249)

---

**References:**  
SSL Bump detection and reporting: [[1]](diffhunk://#diff-af3a24fea247730c6706457baa00680cc4110b3e7fcea654473f5039d29b4d50R928-R1044) [[2]](diffhunk://#diff-5b57956bb005ade5dc3e3d5404f38d2b84e04696b8f3eac8229ff8e3bc890926R1-R27) [[3]](diffhunk://#diff-f8d7af7bbeec5f091a765e1b98ec67c1050ecd1c482a83b64af42f3703fc97c0R6) [[4]](diffhunk://#diff-f8d7af7bbeec5f091a765e1b98ec67c1050ecd1c482a83b64af42f3703fc97c0L24-R31) [[5]](diffhunk://#diff-22cc4af565568186584b862a1aad9ebf963c27b87b7986aa799c6daa39e2f6ccL9-R9) [[6]](diffhunk://#diff-22cc4af565568186584b862a1aad9ebf963c27b87b7986aa799c6daa39e2f6ccR89-R110) [[7]](diffhunk://#diff-22cc4af565568186584b862a1aad9ebf963c27b87b7986aa799c6daa39e2f6ccR205-R224) [[8]](diffhunk://#diff-94248b756b5aa52d0f3af93f4ac9c33a19ec2208d677d8e03be85f89929aa691R15-R23) [[9]](diffhunk://#diff-94248b756b5aa52d0f3af93f4ac9c33a19ec2208d677d8e03be85f89929aa691R47-R58)  
Config parsing improvements: [[1]](diffhunk://#diff-af3a24fea247730c6706457baa00680cc4110b3e7fcea654473f5039d29b4d50R2-R43) [[2]](diffhunk://#diff-af3a24fea247730c6706457baa00680cc4110b3e7fcea654473f5039d29b4d50R77-R87)  
Config splitter regex: [[1]](diffhunk://#diff-28e7ccd463058756e1ffef526bd392e9d27962ec1c37613c562ed205c88d597aL109-R109) [[2]](diffhunk://#diff-28e7ccd463058756e1ffef526bd392e9d27962ec1c37613c562ed205c88d597aL140-R140)  
Frontend enhancements: [[1]](diffhunk://#diff-2c0ca4b66848657a6f61d3083d97210b27128c8df4dea0fc1f962364f0c60eceL5-R10) [[2]](diffhunk://#diff-9d9abf21d8d6a828b57e2ebf9f18ae4cf7653a76105c1ad129daea5f95a4e09bL249-R249)