### PR TITLE
fix: re-enable backup creation for Squid configuration files

### DIFF
--- a/services/squid/squid_config_splitter.py
+++ b/services/squid/squid_config_splitter.py
@@ -218,18 +218,17 @@ class SquidConfigSplitter:
         if not os.path.exists(self.input_file):
             raise FileNotFoundError(f"File not found: {self.input_file}")
 
-        # Backup of squid.conf is disabled by user request.
-        # timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        # backup_file = f"{self.input_file}.bak{timestamp}"
-        # try:
-        #     shutil.copy2(self.input_file, backup_file)
-        #     logger.info(f"Backup created: {backup_file}")
-        # except PermissionError:
-        #     logger.exception("Permission denied to create backup file: %s", backup_file)
-        #     raise RuntimeError("Permission denied to create backup file")
-        # except Exception:
-        #     logger.exception("Failed to create backup file: %s", backup_file)
-        #     raise RuntimeError("Failed to create backup file")
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_file = f"{self.input_file}.bak{timestamp}"
+        try:
+            shutil.copy2(self.input_file, backup_file)
+            logger.info(f"Backup created: {backup_file}")
+        except PermissionError:
+            logger.exception("Permission denied to create backup file: %s", backup_file)
+            raise RuntimeError("Permission denied to create backup file")
+        except Exception:
+            logger.exception("Failed to create backup file: %s", backup_file)
+            raise RuntimeError("Failed to create backup file")
         logger.info("Backup creation disabled: no .bak file generated")
 
         # Create the output directory if it doesn't exist
@@ -253,7 +252,6 @@ class SquidConfigSplitter:
         buffers: dict[str, list[str]] = {}
         pending_comments: list[str] = []
         results: dict[str, int] = {}
-        backup_file = None
         results["_backup_file"] = backup_file
 
         try:

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -862,16 +862,16 @@ class SquidConfigManager:
             return False
 
         try:
-            # Create backup before saving
-            if os.path.exists(filepath):
-                backup_path = (
-                    f"{filepath}.bak{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-                )
-                try:
-                    shutil.copy2(filepath, backup_path)
-                    logger.info(f"Backup created: {backup_path}")
-                except Exception as e:
-                    logger.warning(f"Could not create backup: {e}")
+            # Backup creation disabled by user request
+            # if os.path.exists(filepath):
+            #     backup_path = (
+            #         f"{filepath}.bak{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            #     )
+            #     try:
+            #         shutil.copy2(filepath, backup_path)
+            #         logger.info(f"Backup created: {backup_path}")
+            #     except Exception as e:
+            #         logger.warning(f"Could not create backup: {e}")
 
             with open(filepath, "w", encoding="utf-8") as f:
                 f.write(content)


### PR DESCRIPTION
This pull request changes the backup behavior for configuration files in two places to make it consistent with user requests. Backups are now enabled again in the Squid config splitter, but disabled in the admin utility. Below are the most important changes:

**Squid Config Splitter (`squid_config_splitter.py`):**

* Re-enabled automatic backup creation for `squid.conf` before splitting, including timestamped `.bak` files and error handling for backup failures.
* Ensured the backup file path is stored in the `results` dictionary for reference.

**Admin Utility (`admin.py`):**

* Disabled backup creation before saving modular config files, commenting out the backup logic as per user request.