### PR TITLE
Add conntrack package

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,36 @@ _A modern tool for parsing and analyzing Squid logs, providing a user-friendly d
 apt install git python3 python3-pip python3-venv libmariadb-dev curl
 ```
 
+#### Resetting a client's connections
+
+The **Reset connections** action in a user's menu terminates the active
+network states associated with that user's IP address. This is an operating
+system operation, not a Squid reconfiguration, and requires root-equivalent
+privileges:
+
+- **Linux:** install `conntrack` (`apt install conntrack`) and grant
+  SquidStats the required access to the binary. SquidStats runs
+  `conntrack -D -s IP`.
+- **macOS/BSD:** the action uses `pfctl -k IP`; PF must be enabled, and the
+  process must be allowed to run `pfctl` with administrative privileges.
+- **Other systems:** the interface reports that this capability is not
+  available without modifying any connections.
+
+On Linux, add the following `iptables` rules on the Squid proxy host so that
+`conntrack` can track the proxy connections on port 3128:
+
+```bash
+iptables -t filter -I INPUT -p tcp --dport 3128 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -t filter -I OUTPUT -p tcp --sport 3128 -m state --state ESTABLISHED -j ACCEPT
+iptables -t filter -I FORWARD -p tcp --dport 3128 -j ACCEPT
+iptables -t filter -I FORWARD -p tcp --sport 3128 -j ACCEPT
+```
+
+Resetting only affects states tracked by the host firewall. In a Docker
+installation, or when Squid is behind another NAT device, the operation must
+run on the host that actually maintains those states; otherwise, client
+connections cannot be closed by IP address.
+
 > **Note:** If your Squid proxy **does not use user authentication** (i.e., you do not use login or password for clients), you can keep the **default log format** that comes with Squid. The detailed format below is only required for full compatibility with user-based reports.
 
 - ⚠️ !!Important (Only work before version 7.1) ⚠️ For compatibility with user logs, use this format in /etc/squid/squid.conf:

--- a/README_es.md
+++ b/README_es.md
@@ -200,6 +200,17 @@ una reconfiguración de Squid, y requiere privilegios equivalentes a root:
 - **Otros sistemas:** la interfaz informa que esta capacidad no está
   disponible, sin alterar ninguna conexión.
 
+En Linux, agrega las siguientes reglas de `iptables` en el servidor proxy
+Squid para que `conntrack` pueda rastrear las conexiones del proxy en el
+puerto 3128:
+
+```bash
+iptables -t filter -I INPUT -p tcp --dport 3128 -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -t filter -I OUTPUT -p tcp --sport 3128 -m state --state ESTABLISHED -j ACCEPT
+iptables -t filter -I FORWARD -p tcp --dport 3128 -j ACCEPT
+iptables -t filter -I FORWARD -p tcp --sport 3128 -j ACCEPT
+```
+
 El reseteo solo afecta estados rastreados por el firewall del host. En una
 instalación Docker o con Squid detrás de otro NAT, debe ejecutarse en el host
 que realmente mantiene esos estados; de lo contrario no se podrán cerrar las

--- a/install.sh
+++ b/install.sh
@@ -701,7 +701,7 @@ main() {
         log_msg "INFO" "=== INICIO ACTUALIZACIÓN ==="
         echo "Verificando paquetes instalados..."
         checkPackages
-        configureFirewall
+        #configureFirewall
         echo "Actualizando Servicio..."
         if ! updateOrCloneRepo; then
             error "No se puede continuar con la actualización"
@@ -743,7 +743,7 @@ main() {
         log_msg "INFO" "=== INICIO INSTALACIÓN ==="
         echo "Instalando aplicación web..."
         checkPackages
-        configureFirewall
+        #configureFirewall
 
         # Detectar si ya estamos en el directorio del repo (CI/desarrollo local)
         if [ "$NON_INTERACTIVE" = true ] && [ -f "app.py" ] && [ -f "requirements.txt" ]; then


### PR DESCRIPTION
This pull request introduces documentation improvements and a minor install script change related to the connection reset functionality. The main focus is to clarify how to reset client connections and the necessary firewall rules, both in English and Spanish documentation. Additionally, the `configureFirewall` call is now commented out in the install script.

**Documentation updates:**

* Added a detailed explanation in `README.md` for the "Reset connections" action, including required system commands, privileges, and platform-specific instructions. Also provided recommended `iptables` rules for proper connection tracking on Linux.
* Updated `README_es.md` to include the corresponding `iptables` rules and clarifications for Spanish-speaking users.

**Install script changes:**

* Commented out the `configureFirewall` function call in `install.sh`, both for installation and update flows, likely to prevent automatic firewall changes during these processes. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL704-R704) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL746-R746)